### PR TITLE
chore: README, LICENSE, tsconfig e alinhamento da MenuBar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The BSD Zero Clause License (0BSD)
 
-Copyright (c) 2020 Gatsby Inc.
+Copyright (c) 2026 Reinoldo Sommer
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.

--- a/README.md
+++ b/README.md
@@ -1,99 +1,76 @@
-<!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
-<p align="center">
-  <a href="https://www.gatsbyjs.com">
-    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
-  </a>
-</p>
-<h1 align="center">
-  Gatsby's default starter
-</h1>
+# MyBlog (Reinoldo Sommer)
 
-Kick off your project with this default boilerplate. This starter ships with the main Gatsby configuration files you might need to get up and running blazing fast with the blazing fast app generator for React.
+Blog pessoal estático: **Astro 6**, **React 19** (ilhas para UI interativa), **Tailwind CSS v4** e **Markdown** via content collections. Comentários com Disqus; busca com Algolia (opcional).
 
-_Have another more specific idea? You may want to check out our vibrant collection of [official and community-created starters](https://www.gatsbyjs.com/docs/gatsby-starters/)._
+## Requisitos
 
-## 🚀 Quick start
+- [Node.js](https://nodejs.org/) **22.12+** (ver `engines` em `package.json`)
 
-1.  **Create a Gatsby site.**
+## Começar
 
-    Use the Gatsby CLI to create a new site, specifying the default starter.
+```bash
+npm install
+cp .env.example .env   # opcional; necessário para busca Algolia
+npm run dev
+```
 
-    ```shell
-    # create a new Gatsby site using the default starter
-    gatsby new my-default-starter https://github.com/gatsbyjs/gatsby-starter-default
-    ```
+Abre em `http://localhost:4321` (porta padrão do Astro).
 
-1.  **Start developing.**
+## Scripts
 
-    Navigate into your new site’s directory and start it up.
+| Comando | Descrição |
+| -------- | ----------- |
+| `npm run dev` | Servidor de desenvolvimento |
+| `npm run build` | Gera o site em `dist/` |
+| `npm run preview` | Pré-visualiza a build de produção |
+| `npm run algolia:index` | Envia posts ao índice Algolia (requer env; ver abaixo) |
+| `npm run build:index` | `astro build` + push Algolia (uso local/CI quando a rede estiver OK) |
+| `npm run format` | Prettier nos ficheiros do projeto |
+| `npm test` | `prettier --check` em `src/` |
 
-    ```shell
-    cd my-default-starter/
-    gatsby develop
-    ```
+## Estrutura (resumo)
 
-1.  **Open the source code and start editing!**
+| Caminho | Conteúdo |
+| -------- | ---------- |
+| `src/content/posts/` | Artigos Markdown + frontmatter |
+| `src/content.config.ts` | Schema Zod das collections |
+| `src/pages/` | Rotas Astro (`index`, `[slug]`, `page/[page]`, `about`, `search`, `404`) |
+| `src/layouts/Base.astro` | HTML base, tema claro/escuro, CSS global |
+| `src/styles/tailwind.css` | Tailwind + variáveis de tema + estilos de markdown / Algolia |
+| `src/components/` | Componentes React (layout, lista, busca, etc.) |
+| `src/lib/` | Helpers (`posts`, `slug`, `markdown`) |
+| `public/admin/` | Decap CMS (Netlify CMS) |
+| `scripts/push-algolia.mjs` | Indexação Algolia a partir dos `.md` |
 
-    Your site is now running at `http://localhost:8000`!
+## Posts
 
-    _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.com/tutorial/part-five/#introducing-graphiql)._
+Ficheiros em `src/content/posts/` com nomes no formato `YYYY-MM-DD-slug.md`. O slug público segue a mesma regra de antes (prefixo de data removido na URL), por exemplo `/my-first-ireland-trip/`.
 
-    Open the `my-default-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
+Frontmatter típico: `title`, `description`, `date`, `category`, `background` (opcional).
 
-## 🧐 What's inside?
+## Variáveis de ambiente
 
-A quick look at the top-level files and directories you'll see in a Gatsby project.
+Copia `.env.example` para `.env`. Variáveis `PUBLIC_*` são expostas ao cliente (InstantSearch).
 
-    .
-    ├── node_modules
-    ├── src
-    ├── .gitignore
-    ├── .prettierrc
-    ├── gatsby-browser.js
-    ├── gatsby-config.js
-    ├── gatsby-node.js
-    ├── gatsby-ssr.js
-    ├── LICENSE
-    ├── package-lock.json
-    ├── package.json
-    └── README.md
+- **Busca no browser:** `PUBLIC_ALGOLIA_APP_ID`, `PUBLIC_ALGOLIA_SEARCH_KEY`, `PUBLIC_ALGOLIA_INDEX_NAME`
+- **Só no script de indexação:** `ALGOLIA_ADMIN_KEY` (nunca commits nem `PUBLIC_`)
 
-1.  **`/node_modules`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
+O script também aceita nomes legados `GATSBY_ALGOLIA_*` para app id e nome do índice, mas o ideal é migrar para `PUBLIC_*`.
 
-2.  **`/src`**: This directory will contain all of the code related to what you will see on the front-end of your site (what you see in the browser) such as your site header or a page template. `src` is a convention for “source code”.
+Se precisares de saltar o push no meio de outro comando, define `SKIP_ALGOLIA_INDEX=true`.
 
-3.  **`.gitignore`**: This file tells git which files it should not track / not maintain a version history for.
+## Deploy (Netlify)
 
-4.  **`.prettierrc`**: This is a configuration file for [Prettier](https://prettier.io/). Prettier is a tool to help keep the formatting of your code consistent.
+- **Comando:** `npm run build` (definido em `netlify.toml`)
+- **Publish:** `dist`
+- **Node:** 22 (via `netlify.toml`)
 
-5.  **`gatsby-browser.js`**: This file is where Gatsby expects to find any usage of the [Gatsby browser APIs](https://www.gatsbyjs.com/docs/browser-apis/) (if any). These allow customization/extension of default Gatsby settings affecting the browser.
+O push Algolia **não** corre no deploy por predefinição (evita falhas de build se a API estiver inacessível). Para atualizar o índice, corre `npm run algolia:index` localmente ou noutro job com as variáveis corretas.
 
-6.  **`gatsby-config.js`**: This is the main configuration file for a Gatsby site. This is where you can specify information about your site (metadata) like the site title and description, which Gatsby plugins you’d like to include, etc. (Check out the [config docs](https://www.gatsbyjs.com/docs/gatsby-config/) for more detail).
+## CMS
 
-7.  **`gatsby-node.js`**: This file is where Gatsby expects to find any usage of the [Gatsby Node APIs](https://www.gatsbyjs.com/docs/node-apis/) (if any). These allow customization/extension of default Gatsby settings affecting pieces of the site build process.
+Painel em `/admin/` (ficheiros em `public/admin/`). Ajusta `media_folder` / `public_folder` em `config.yml` se mudares a estrutura de imagens.
 
-8.  **`gatsby-ssr.js`**: This file is where Gatsby expects to find any usage of the [Gatsby server-side rendering APIs](https://www.gatsbyjs.com/docs/ssr-apis/) (if any). These allow customization of default Gatsby settings affecting server-side rendering.
+## Licença
 
-9.  **`LICENSE`**: This Gatsby starter is licensed under the 0BSD license. This means that you can see this file as a placeholder and replace it with your own license.
-
-10. **`package-lock.json`** (See `package.json` below, first). This is an automatically generated file based on the exact versions of your npm dependencies that were installed for your project. **(You won’t change this file directly).**
-
-11. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
-
-12. **`README.md`**: A text file containing useful reference information about your project.
-
-## 🎓 Learning Gatsby
-
-Looking for more guidance? Full documentation for Gatsby lives [on the website](https://www.gatsbyjs.com/). Here are some places to start:
-
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://www.gatsbyjs.com/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
-
-- **To dive straight into code samples, head [to our documentation](https://www.gatsbyjs.com/docs/).** In particular, check out the _Guides_, _API Reference_, and _Advanced Tutorials_ sections in the sidebar.
-
-## 💫 Deploy
-
-[Build, Deploy, and Host On The Only Cloud Built For Gatsby](https://www.gatsbyjs.com/cloud/)
-
-Gatsby Cloud is an end-to-end cloud platform specifically built for the Gatsby framework that combines a modern developer experience with an optimized, global edge network.
-
-<!-- AUTO-GENERATED-CONTENT:END -->
+0BSD — ver `package.json`.

--- a/src/components/MenuBar/index.jsx
+++ b/src/components/MenuBar/index.jsx
@@ -27,34 +27,34 @@ export default function MenuBar({ pathname = "/" }) {
   const homeActive = pathMatches(pathname, "/");
 
   const itemBase =
-    "relative block h-[3.75rem] w-8 cursor-pointer p-[1.1rem] text-[var(--texts)] hover:text-[var(--highlight)] max-[1170px]:h-10 max-[1170px]:w-10 max-[1170px]:p-[0.9rem]";
+    "relative flex h-[3.75rem] w-full cursor-pointer items-center justify-center text-[var(--texts)] hover:text-[var(--highlight)] max-[1170px]:h-10 max-[1170px]:w-10 max-[1170px]:shrink-0 max-[1170px]:p-[0.9rem]";
 
   return (
     <aside
-      className="fixed right-0 top-0 z-10 flex h-screen w-[3.75rem] flex-col items-center justify-between border-l border-[var(--borders)] bg-[var(--mediumBackground)] py-2 transition-colors duration-500 max-[1170px]:bottom-0 max-[1170px]:top-auto max-[1170px]:h-auto max-[1170px]:w-full max-[1170px]:flex-row max-[1170px]:border-l-0 max-[1170px]:border-t max-[1170px]:p-0"
+      className="fixed right-0 top-0 z-10 flex h-screen w-[3.75rem] flex-col items-stretch justify-between border-l border-[var(--borders)] bg-[var(--mediumBackground)] py-2 transition-colors duration-500 max-[1170px]:bottom-0 max-[1170px]:top-auto max-[1170px]:h-auto max-[1170px]:w-full max-[1170px]:flex-row max-[1170px]:items-center max-[1170px]:border-l-0 max-[1170px]:border-t max-[1170px]:p-0"
       aria-label="Toolbar"
     >
-      <div className="flex flex-col max-[1170px]:flex-row">
+      <div className="flex w-full flex-col max-[1170px]:w-auto max-[1170px]:flex-row">
         <a
           href="/"
           title="Comeback to home"
           className={
             homeActive
-              ? "block [&>span]:text-[var(--highlight)]"
-              : "block"
+              ? "block w-full max-[1170px]:w-auto [&>span]:text-[var(--highlight)]"
+              : "block w-full max-[1170px]:w-auto"
           }
         >
           <span className={itemBase}>
             <Home className={iconClass} />
           </span>
         </a>
-        <a href="/search/" title="Search" className="block">
+        <a href="/search/" title="Search" className="block w-full max-[1170px]:w-auto">
           <span className={itemBase}>
             <Search className={iconClass} />
           </span>
         </a>
       </div>
-      <div className="flex flex-col max-[1170px]:flex-row">
+      <div className="flex w-full flex-col max-[1170px]:w-auto max-[1170px]:flex-row">
         <span
           title="Change theme"
           role="button"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/strict",
+  "extends": "./node_modules/astro/tsconfigs/strict.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",


### PR DESCRIPTION
# Contexto

Após **rebase**, `develop` fica **um único commit** à frente de `main`. O stack do blog já está em **Astro** em `main`; este PR traz só ajustes complementares: documentação e licença alinhadas ao projeto atual, correção da resolução do `extends` no TypeScript e alinhamento visual dos ícones na `MenuBar`.

# O que mudou

- **LICENSE:** copyright atualizado (Reinoldo Sommer, 0BSD).
- **README:** revisão da estrutura e instruções para o repositório Astro (setup, build, Algolia, etc.).
- **tsconfig.json:** `extends` apontando para `./node_modules/astro/tsconfigs/strict.json` para o `tsc` e o editor resolverem o preset corretamente.
- **MenuBar:** itens em `flex` com `w-full` e centralização na coluna vertical da barra lateral.

# Arquivos principais

- `README.md`, `LICENSE`
- `tsconfig.json`
- `src/components/MenuBar/index.jsx`

# Testes e cobertura

N/A. Não há novos testes automatizados; `npm test` segue como checagem de Prettier.

# Validação

- `npm run build`
- `npx tsc --noEmit`
- Conferir visualmente a `MenuBar` em viewport largo (barra fixa à direita).

# Observações

- O histórico foi condensado em **um commit**; a mensagem do commit pode ainda enfatizar só README/LICENSE — o diff, porém, inclui também `tsconfig.json` e `MenuBar`. Se quiser o histórico mais explícito, dá para ajustar com `git commit --amend` antes do merge (opcional).
